### PR TITLE
feat: remove modal centering

### DIFF
--- a/src/Components/Modal.js
+++ b/src/Components/Modal.js
@@ -22,7 +22,7 @@ export class Modal extends React.Component{
 
 
       <div className="modal fade" id={`${this.props.auteur+this.props.montant}`} tabIndex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-        <div className="modal-dialog modal-dialog-centered" role="document">
+        <div className="modal-dialog top-aligned" role="document">
       
           <div className="modalelements">
           <div className="modalrow1">

--- a/src/Css-files/Modal.css
+++ b/src/Css-files/Modal.css
@@ -213,6 +213,13 @@
 }
 
 
+.modal-dialog.top-aligned {
+  margin: 0 auto;
+  margin-top: 40px;
+  max-height: calc(100vh - 80px);
+  overflow-y: auto;
+}
+
 .row.hideit{
   display: none;
 }


### PR DESCRIPTION
## Summary
- stop vertical centering by replacing Bootstrap class with custom `top-aligned`
- add CSS to position modal near top and keep content within viewport

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf7e32338c832b82f8d117f722d6d0