### PR TITLE
Guard smooth scrolling for hash anchors

### DIFF
--- a/public/JS/scripts2.js
+++ b/public/JS/scripts2.js
@@ -10,10 +10,13 @@ $(window).on('scroll load', function() {
   $(function() {
     $(document).on('click', 'a.page-scroll', function(event) {
         var $anchor = $(this);
-        $('html, body').stop().animate({
-            scrollTop: $($anchor.attr('href')).offset().top
-        }, 600, 'easeInOutExpo');
-        event.preventDefault();
+        var target = $anchor.attr('href');
+        if (target && target.startsWith('#')) {
+            $('html, body').stop().animate({
+                scrollTop: $(target).offset().top
+            }, 600, 'easeInOutExpo');
+            event.preventDefault();
+        }
     });
 });
 

--- a/src/Components/Navigation.js
+++ b/src/Components/Navigation.js
@@ -20,26 +20,26 @@ render(){
         <div className="collapse navbar-collapse" id="navbarsExampleDefault">
             <ul className="navbar-nav ml-auto">
                 <li className="nav-item">
-                    <NavLink to="/" className="nav-link page-scroll"><span className="menuitem">Accueil <i className="bi bi-house-door-fill"></i>  </span><span className="sr-only">(current)</span></NavLink>
+                    <NavLink to="/" className="nav-link"><span className="menuitem">Accueil <i className="bi bi-house-door-fill"></i>  </span><span className="sr-only">(current)</span></NavLink>
                 </li>
                 <li className="nav-item">
-                    <NavLink className="nav-link page-scroll" to="/Collection">Ma collection <i className="bi bi-bookmarks-fill"></i></NavLink>
+                    <NavLink className="nav-link" to="/Collection">Ma collection <i className="bi bi-bookmarks-fill"></i></NavLink>
                 </li>
                 <li className="nav-item">
-                    <NavLink className="nav-link page-scroll" to="/Messages">Messages <i className="bi bi-chat-left-fill"></i>  </NavLink>
+                    <NavLink className="nav-link" to="/Messages">Messages <i className="bi bi-chat-left-fill"></i>  </NavLink>
                 </li>
 
               
 
 
                 <li className="nav-item">
-                    <NavLink className="nav-link page-scroll" to="/Ajouter">Ajouter un produit  <i className="bi bi-plus-square-fill"></i></NavLink>
+                    <NavLink className="nav-link" to="/Ajouter">Ajouter un produit  <i className="bi bi-plus-square-fill"></i></NavLink>
                 </li>
 
                 
 
                 <li className="nav-item">
-                    <NavLink to="/panier" className="nav-link page-scroll" >Panier <i className="bi bi-bag-fill"></i><span className='badge badge-warning' id='lblCartCount'> {this.props.cartcount} </span></NavLink>
+                    <NavLink to="/panier" className="nav-link" >Panier <i className="bi bi-bag-fill"></i><span className='badge badge-warning' id='lblCartCount'> {this.props.cartcount} </span></NavLink>
                 </li>
             </ul>
 


### PR DESCRIPTION
## Summary
- Prevent smooth scroll handler from intercepting non-hash links
- Drop `page-scroll` class from navigation links that route to other pages

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bf81758770832ba9d930639d4c6b8b