### PR TITLE
Add WhatsApp contact handler

### DIFF
--- a/src/Components/Carte.js
+++ b/src/Components/Carte.js
@@ -4,6 +4,14 @@ import { Modal } from "./Modal"
 import axios from 'axios';
 
 
+export const handleWhatsApp = (item) => {
+  const imageUrl = item.src && item.src.startsWith('http') ? item.src : `${window.location.origin}${item.src}`;
+  const message = `${item.titre} - ${item.montant} ${imageUrl}`;
+  const url = `https://wa.me/5147727974?text=${encodeURIComponent(message)}`;
+  window.open(url, '_blank');
+};
+
+
 
 
 
@@ -116,7 +124,7 @@ export class Seller extends React.Component{
   
       <Seller titre={this.props.titre} idproductInfo={`${this.props.auteur+this.props.montant+"info"}`} hideModal={this.hideModal} showModal={this.showModal} Addproduct={this.props.Addproduct} src={this.props.src} montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description}/>
       
-      <Modal show={this.state.show} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description}/>
+      <Modal show={this.state.show} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre}/>
   
       
       </div>

--- a/src/Components/Commentaires.js
+++ b/src/Components/Commentaires.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { images } from "../data/images";
+import { handleWhatsApp } from "./Carte";
 
 
 
@@ -153,7 +154,7 @@ export class Description extends React.Component{
                 <div className="optionscontact">
                     <div className="opt1">
                     <h6>Contacter</h6>
-                    <button type="button" className="btn btn-light plus"><i className="bi bi-whatsapp bigger"></i></button>
+                    <button type="button" className="btn btn-light plus" onClick={() => handleWhatsApp({titre: this.props.titre, montant: this.props.montant, src: this.props.src})}><i className="bi bi-whatsapp bigger"></i></button>
                     </div>
                     <div className="opt1">
                     <h6>Ajouter au panier</h6>

--- a/src/Components/Modal.js
+++ b/src/Components/Modal.js
@@ -53,10 +53,10 @@ export class Modal extends React.Component{
           <div className="modalcell2">
             <Options  iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`}   idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} />
             
-            <Description  show={this.props.show} idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`} src={this.props.src}  montant={this.props.montant + '$'} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description}/>
-      
-           
-            <Commentaires  show={this.props.show} idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`} src={this.props.src}  montant={this.props.montant + '$'} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description}/>
+            <Description  show={this.props.show} idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`} src={this.props.src}  montant={this.props.montant + '$'} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre}/>
+
+
+            <Commentaires  show={this.props.show} idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`} src={this.props.src}  montant={this.props.montant + '$'} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre}/>
       
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Add reusable `handleWhatsApp` helper to build WhatsApp messaging URL
- Wire up product description contact button to launch WhatsApp with product details
- Pass product title through modal layers so handler has necessary data

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf83e9a944832bb26901d237044697