### PR TITLE
Fix cart cloning and cart count

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -73,17 +73,16 @@ async componentDidMount() {
   }
 }
 
-  Addproduct=(img)=>{
-    let kart = this.state.cart ;
-      const index = this.state.cart.findIndex(object=>object._id === img._id);
-      if(index === -1){
-        img.qty=1;
-        kart.push(img)  
-      }else{
-        img.qty++;
-      }
-    this.setState({cart:kart})
-  }
+  Addproduct = (img) => {
+    const kart = [...this.state.cart];
+    const index = kart.findIndex((object) => object._id === img._id);
+    if (index === -1) {
+      kart.push({ ...img, qty: 1 });
+    } else {
+      kart[index].qty++;
+    }
+    this.setState({ cart: kart });
+  };
 
   AddtoCollection=(img)=>{
 
@@ -96,28 +95,50 @@ console.log(img)
  
 
 
-  render(){
+  render() {
+    const cartCount = this.state.cart.reduce((sum, p) => sum + p.qty, 0);
     return (
       <BrowserRouter>
-      <div className="App">
-        
-       
-        <Navigation cartcount= {this.state.cart.length} />
-        <Routes>
-        <Route path="/" element={<Mycart elementscart={this.state.cart} produits={this.state.produits}  Addproduct={this.Addproduct} />} />
-       <Route path="/panier" element={  <Pagepanier cartcount={this.state.cart.length} Addmore={this.Addmore} cart ={this.state.cart}/>}  />
-       <Route  path="/Ajouter" element={<AjouterProduit/>}/>  
-       <Route  path="/Collection" element={<div><h1>Collection</h1><div className='row'><InstaCarteproduit /></div></div>}/>  
-       <Route  path="/Messages" element={<h1>Messages</h1>}/>  
-
-
-
-        </Routes>
-        
+        <div className="App">
+          <Navigation totalCount={cartCount} />
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <Mycart
+                  elementscart={this.state.cart}
+                  produits={this.state.produits}
+                  Addproduct={this.Addproduct}
+                />
+              }
+            />
+            <Route
+              path="/panier"
+              element={
+                <Pagepanier
+                  totalCount={cartCount}
+                  Addmore={this.Addmore}
+                  cart={this.state.cart}
+                />
+              }
+            />
+            <Route path="/Ajouter" element={<AjouterProduit />} />
+            <Route
+              path="/Collection"
+              element={
+                <div>
+                  <h1>Collection</h1>
+                  <div className='row'>
+                    <InstaCarteproduit />
+                  </div>
+                </div>
+              }
+            />
+            <Route path="/Messages" element={<h1>Messages</h1>} />
+          </Routes>
         </div>
-        </BrowserRouter>
+      </BrowserRouter>
     );
-
   }
 
   

--- a/src/Components/Monpanier.js
+++ b/src/Components/Monpanier.js
@@ -19,7 +19,7 @@ export class Pagepanier extends React.Component{
       </div>
       <aside>
        <div class="summary">
-        <div class="summary-total-items"><span class="total-items">{this.props.cartcount}</span> Items in your Bag</div>
+       <div class="summary-total-items"><span class="total-items">{this.props.totalCount}</span> Items in your Bag</div>
         <div class="summary-subtotal">
           <div class="subtotal-title">Subtotal</div>
           <div class="subtotal-value final-value" id="basket-subtotal">130.00</div>

--- a/src/Components/Navigation.js
+++ b/src/Components/Navigation.js
@@ -39,7 +39,7 @@ render(){
                 
 
                 <li className="nav-item">
-                    <NavLink to="/panier" className="nav-link page-scroll" >Panier <i className="bi bi-bag-fill"></i><span className='badge badge-warning' id='lblCartCount'> {this.props.cartcount} </span></NavLink>
+                    <NavLink to="/panier" className="nav-link page-scroll" >Panier <i className="bi bi-bag-fill"></i><span className='badge badge-warning' id='lblCartCount'> {this.props.totalCount} </span></NavLink>
                 </li>
             </ul>
 


### PR DESCRIPTION
## Summary
- clone products when adding to cart to avoid mutating catalog data
- derive total cart item count from quantities and pass to navigation and basket

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf83e2c818832b9a2759fcbf9a4dd1