### PR TITLE
Add WhatsApp ordering option

### DIFF
--- a/src/Components/Monpanier.js
+++ b/src/Components/Monpanier.js
@@ -3,8 +3,13 @@ import { Modal } from "./Modal";
 import './Carte'
 import { Entete } from  './Entetes';
 
-
-
+function sendCartToWhatsApp(cart) {
+  const orderMessage = cart
+    .map(item => `- ${item.titre} x${item.qty} (${item.montant}$)`)
+    .join('\n');
+  const url = `https://wa.me/5147727974?text=${encodeURIComponent(orderMessage)}`;
+  window.open(url, '_blank');
+}
 
 export class Pagepanier extends React.Component{
   render(){
@@ -52,6 +57,7 @@ export class Pagepanier extends React.Component{
 
         <div class="summary-checkout">
           <button class="checkout-cta">Go to Secure Checkout</button>
+          <button class="checkout-cta" onClick={() => sendCartToWhatsApp(this.props.cart)}>Order via WhatsApp</button>
         </div>
       </div>
        </aside>


### PR DESCRIPTION
## Summary
- add sendCartToWhatsApp to build WhatsApp order messages
- expose "Order via WhatsApp" button alongside checkout

## Testing
- `npm test` *(fails: No tests found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bf89948514832b823bb20978f83c54