### PR TITLE
Enable adding products to cart from modal

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -118,6 +118,7 @@ console.log(img)
                 <Pagepanier
                   totalCount={cartCount}
                   Addmore={this.Addmore}
+                  Addproduct={this.Addproduct}
                   cart={this.state.cart}
                 />
               }
@@ -129,7 +130,7 @@ console.log(img)
                 <div>
                   <h1>Collection</h1>
                   <div className='row'>
-                    <InstaCarteproduit />
+                    <InstaCarteproduit Addproduct={this.Addproduct} />
                   </div>
                 </div>
               }

--- a/src/Components/Carte.js
+++ b/src/Components/Carte.js
@@ -124,7 +124,7 @@ export class Seller extends React.Component{
   
       <Seller titre={this.props.titre} idproductInfo={`${this.props.auteur+this.props.montant+"info"}`} hideModal={this.hideModal} showModal={this.showModal} Addproduct={this.props.Addproduct} src={this.props.src} montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description}/>
       
-      <Modal show={this.state.show} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre}/>
+      <Modal Addproduct={this.props.Addproduct} show={this.state.show} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre}/>
   
       
       </div>
@@ -197,7 +197,7 @@ axios.request(options)
   
   
       
-      <Modal show={this.state.show} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.state.igdesc}/>
+      <Modal Addproduct={this.props.Addproduct} show={this.state.show} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.state.igdesc}/>
   
       
       </div>

--- a/src/Components/Commentaires.js
+++ b/src/Components/Commentaires.js
@@ -140,12 +140,21 @@ export class Commentaires extends React.Component{
 export class Description extends React.Component{
 
 
-    
+
     render(){
+        const product = {
+            src: this.props.src,
+            auteur: this.props.auteur,
+            montant: this.props.montant,
+            profil: this.props.profil,
+            description: this.props.description,
+            titre: this.props.titre,
+            _id: this.props._id
+        };
         return(
             <div className="row" id={this.props.iddesc}>
                 <div className="descrip">
-                    <h4 className="opt1 ">{this.props.montant}</h4>
+                    <h4 className="opt1 ">{this.props.montant + '$'}</h4>
                 <h5>Description</h5>
                 <div > <p className="opt1  ">{this.props.description}</p></div>
                 </div>
@@ -158,7 +167,7 @@ export class Description extends React.Component{
                     </div>
                     <div className="opt1">
                     <h6>Ajouter au panier</h6>
-                    <button type="button" className="btn btn-light plus"><i className="bi bi-cart-plus bigger"></i></button>
+                    <button type="button" className="btn btn-light plus" onClick={() => this.props.Addproduct(product)}><i className="bi bi-cart-plus bigger"></i></button>
                     </div>
                     <div className="opt1">
                     <h6>Enregistrer</h6>

--- a/src/Components/Modal.js
+++ b/src/Components/Modal.js
@@ -53,7 +53,7 @@ export class Modal extends React.Component{
           <div className="modalcell2">
             <Options  iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`}   idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} />
             
-            <Description  show={this.props.show} idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`} src={this.props.src}  montant={this.props.montant + '$'} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre}/>
+            <Description  Addproduct={this.props.Addproduct} show={this.props.show} idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre}/>
 
 
             <Commentaires  show={this.props.show} idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`} src={this.props.src}  montant={this.props.montant + '$'} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre}/>

--- a/src/Components/Monpanier.js
+++ b/src/Components/Monpanier.js
@@ -20,7 +20,7 @@ export class Pagepanier extends React.Component{
         <main>
         <div className="basket">
        
-        <ListePanier  Addmore={this.props.Addmore} cart={this.props.cart}/>
+        <ListePanier  Addmore={this.props.Addmore} Addproduct={this.props.Addproduct} cart={this.props.cart}/>
       </div>
       <aside>
        <div class="summary">
@@ -101,7 +101,7 @@ export class Pagepanier extends React.Component{
         </div>
     </div>
 </div>
-<Modal src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} />
+<Modal Addproduct={this.props.Addproduct} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre} />
 </div>)
     }
 
@@ -153,7 +153,7 @@ export class Pagepanier extends React.Component{
 
 
 
-<Modal src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} />
+<Modal Addproduct={this.props.Addproduct} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre} />
 </div>)
     }
 
@@ -163,7 +163,7 @@ export class Pagepanier extends React.Component{
 
  export  class ListePanier extends React.Component{
     render(){
-      return(this.props.cart.map(img=>{ return(<Cartepanier Addmore={this.props.Addmore.bind(this,img)} id={img._id} titre={img.titre} key={img.montant+img.src} src={img.src} description={img.description} auteur={img.auteur} montant={img.montant} qty={img.qty}/>)}))
+      return(this.props.cart.map(img=>{ return(<Cartepanier Addmore={this.props.Addmore.bind(this,img)} Addproduct={this.props.Addproduct} id={img._id} titre={img.titre} key={img.montant+img.src} src={img.src} description={img.description} auteur={img.auteur} montant={img.montant} qty={img.qty} profil={img.profil}/>)}))
     }
   }
 


### PR DESCRIPTION
## Summary
- Pass `Addproduct` through `Modal` to `Description`
- Hook cart icon in `Description` to call `Addproduct`
- Provide `Addproduct` to all modal usages so cart updates from modal views

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bf8eeb02c0832b9ffdf03283480a85