### PR TITLE
refactor: remove unused Carte import

### DIFF
--- a/src/Components/Monpanier.js
+++ b/src/Components/Monpanier.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { Modal } from "./Modal";
-import './Carte';
 import { Entete } from './Entetes';
 
 function sendCartToWhatsApp(cart) {


### PR DESCRIPTION
## Summary
- remove unused `import './Carte'` from Monpanier component
- verified no other references rely on Carte module side effects

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bf91e41998832b9ba7cbd5d8b918d8