### PR TITLE
Propagate Addproduct handler into modal description

### DIFF
--- a/src/Components/Carte.js
+++ b/src/Components/Carte.js
@@ -124,7 +124,7 @@ export class Seller extends React.Component{
   
       <Seller titre={this.props.titre} idproductInfo={`${this.props.auteur+this.props.montant+"info"}`} hideModal={this.hideModal} showModal={this.showModal} Addproduct={this.props.Addproduct} src={this.props.src} montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description}/>
       
-      <Modal show={this.state.show} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre}/>
+      <Modal show={this.state.show} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre} Addproduct={this.props.Addproduct}/>
   
       
       </div>

--- a/src/Components/Commentaires.js
+++ b/src/Components/Commentaires.js
@@ -158,7 +158,23 @@ export class Description extends React.Component{
                     </div>
                     <div className="opt1">
                     <h6>Ajouter au panier</h6>
-                    <button type="button" className="btn btn-light plus"><i className="bi bi-cart-plus bigger"></i></button>
+                    <button
+                      type="button"
+                      className="btn btn-light plus"
+                      onClick={() =>
+                        this.props.Addproduct({
+                          src: this.props.src,
+                          auteur: this.props.auteur,
+                          montant: this.props.montant,
+                          profil: this.props.profil,
+                          titre: this.props.titre,
+                          description: this.props.description,
+                          id: this.props.id,
+                        })
+                      }
+                    >
+                      <i className="bi bi-cart-plus bigger"></i>
+                    </button>
                     </div>
                     <div className="opt1">
                     <h6>Enregistrer</h6>

--- a/src/Components/Modal.js
+++ b/src/Components/Modal.js
@@ -53,7 +53,7 @@ export class Modal extends React.Component{
           <div className="modalcell2">
             <Options  iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`}   idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} />
             
-            <Description  show={this.props.show} idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`} src={this.props.src}  montant={this.props.montant + '$'} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre}/>
+            <Description  show={this.props.show} idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`} src={this.props.src}  montant={this.props.montant + '$'} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre} Addproduct={this.props.Addproduct}/>
 
 
             <Commentaires  show={this.props.show} idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`} src={this.props.src}  montant={this.props.montant + '$'} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre}/>


### PR DESCRIPTION
## Summary
- pass Addproduct handler from product card into modal
- invoke Addproduct from Description component's cart button
- wire modal creation with Addproduct handler

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bf967e5f48832bb7636268c5e406fb