### PR TITLE
Use consistent product id for cart operations

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -65,7 +65,7 @@ async componentDidMount() {
     const data = await response.json();
     const dataWithIds = data.map((p, idx) => ({
       ...p,
-      id: p.id || p._id || `${p.src || ''}-${p.titre || idx}`
+      id: p.id || `${p.src || ''}-${p.titre || idx}`
     }));
     this.setState({ produits: dataWithIds });
     console.log('✅ Products loaded from Supabase:', dataWithIds.length, 'items');
@@ -82,7 +82,7 @@ async componentDidMount() {
 }
 
   Addproduct = (img) => {
-    const productId = img.id || img._id || `${img.src}-${img.titre}`;
+    const productId = img.id || `${img.src}-${img.titre}`;
     const kart = [...this.state.cart];
     const index = kart.findIndex((object) => object.id === productId);
     if (index === -1) {


### PR DESCRIPTION
## Summary
- Normalize product IDs from Supabase and fallback data using `id` or a composite of `src` and `titre`
- Remove `_id` usage and match cart items solely by `id`

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68bf97e367c8832bbccab91d15428f56