### PR TITLE
Propagate Addproduct handler to modals

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -128,6 +128,7 @@ console.log(img)
                   totalCount={cartCount}
                   Addmore={this.Addmore}
                   cart={this.state.cart}
+                  Addproduct={this.Addproduct}
                 />
               }
             />
@@ -138,7 +139,7 @@ console.log(img)
                 <div>
                   <h1>Collection</h1>
                   <div className='row'>
-                    <InstaCarteproduit />
+                    <InstaCarteproduit Addproduct={this.Addproduct} />
                   </div>
                 </div>
               }

--- a/src/Components/Carte.js
+++ b/src/Components/Carte.js
@@ -123,7 +123,7 @@ export class Seller extends React.Component{
   
   
       <Seller titre={this.props.titre} idproductInfo={`${this.props.auteur+this.props.montant+"info"}`} hideModal={this.hideModal} showModal={this.showModal} Addproduct={this.props.Addproduct} src={this.props.src} montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description}/>
-      
+
       <Modal show={this.state.show} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre} Addproduct={this.props.Addproduct}/>
   
       
@@ -197,7 +197,7 @@ axios.request(options)
   
   
       
-      <Modal show={this.state.show} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.state.igdesc}/>
+        <Modal show={this.state.show} src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.state.igdesc} Addproduct={this.props.Addproduct}/>
   
       
       </div>

--- a/src/Components/Commentaires.js
+++ b/src/Components/Commentaires.js
@@ -161,8 +161,8 @@ export class Description extends React.Component{
                     <button
                       type="button"
                       className="btn btn-light plus"
-                      onClick={() =>
-                        this.props.Addproduct({
+                      onClick={() => {
+                        const product = {
                           src: this.props.src,
                           auteur: this.props.auteur,
                           montant: this.props.montant,
@@ -170,8 +170,9 @@ export class Description extends React.Component{
                           titre: this.props.titre,
                           description: this.props.description,
                           id: this.props.id,
-                        })
-                      }
+                        };
+                        this.props.Addproduct(product);
+                      }}
                     >
                       <i className="bi bi-cart-plus bigger"></i>
                     </button>

--- a/src/Components/Modal.js
+++ b/src/Components/Modal.js
@@ -17,56 +17,92 @@ export class Modal extends React.Component{
   //{(this.props.show)?"modal showit":"modal"}
   
     render(){
-    return (
-      
+      const {
+        show,
+        src,
+        montant,
+        auteur,
+        profil,
+        description,
+        titre,
+        Addproduct,
+      } = this.props;
+      return (
+        <div
+          className="modal fade"
+          id={`${auteur + montant}`}
+          tabIndex="-1"
+          role="dialog"
+          aria-labelledby="exampleModalCenterTitle"
+          aria-hidden="true"
+        >
+          <div className="modal-dialog top-aligned" role="document">
+            <div className="modalelements">
+              <div className="modalrow1">
+                <div className="modalcell">
+                  <div>
+                    <div className="seller">
+                      <div className="options">
+                        <button
+                          type="button"
+                          className="btn btn-light plus"
+                          data-dismiss="modal"
+                          aria-label="Close"
+                        >
+                          <i className="bi bi-arrows-angle-contract"></i>
+                        </button>
+                      </div>
 
+                      <div className="sellerinfo">
+                        <span className="auteur">{auteur}</span>
+                        <img className="profil" src={profil} />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="modalrow">
+                <div className="modalcell" id="i7ai">
+                  <a href={src}>
+                    <img className="rectangle" src={src} />
+                  </a>
+                </div>
+                <div className="modalcell2">
+                  <Options
+                    iddesc={`${auteur + montant + montant}desc`}
+                    idcom={`${auteur + montant + montant}`}
+                  />
 
-      <div className="modal fade" id={`${this.props.auteur+this.props.montant}`} tabIndex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-        <div className="modal-dialog top-aligned" role="document">
-      
-          <div className="modalelements">
-          <div className="modalrow1">
-          <div className="modalcell">
-          <div>
-            <div className="seller">
-            <div className="options">
-           <button type="button" className="btn btn-light plus"data-dismiss="modal" aria-label="Close"><i className="bi bi-arrows-angle-contract"></i></button>
-      
-          </div>
-              
-            <div className="sellerinfo">
-                <span  className="auteur">{this.props.auteur}</span> 
-              <img className="profil" src={this.props.profil} />
+                  <Description
+                    show={show}
+                    idcom={`${auteur + montant + montant}`}
+                    iddesc={`${auteur + montant + montant}desc`}
+                    src={src}
+                    montant={montant + '$'}
+                    auteur={auteur}
+                    profil={profil}
+                    description={description}
+                    titre={titre}
+                    Addproduct={Addproduct}
+                  />
+
+                  <Commentaires
+                    show={show}
+                    idcom={`${auteur + montant + montant}`}
+                    iddesc={`${auteur + montant + montant}desc`}
+                    src={src}
+                    montant={montant + '$'}
+                    auteur={auteur}
+                    profil={profil}
+                    description={description}
+                    titre={titre}
+                  />
+                </div>
+              </div>
             </div>
           </div>
-        
-          </div>
-      
-          </div>
         </div>
-        <div className="modalrow">
-       
-          <div className="modalcell" id="i7ai">
-        
-          <a href={this.props.src}><img className="rectangle" src={this.props.src} /></a>
-          </div>
-          <div className="modalcell2">
-            <Options  iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`}   idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} />
-            
-            <Description  show={this.props.show} idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`} src={this.props.src}  montant={this.props.montant + '$'} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre} Addproduct={this.props.Addproduct}/>
-
-
-            <Commentaires  show={this.props.show} idcom={`${this.props.auteur+this.props.montant+this.props.montant}`} iddesc={`${this.props.auteur+this.props.montant+this.props.montant}desc`} src={this.props.src}  montant={this.props.montant + '$'} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} titre={this.props.titre}/>
-      
-          </div>
-        </div>
-          </div>
-      
-        </div>
-      </div>
-            
-     
-    )
+      );
     }
   }
   

--- a/src/Components/Monpanier.js
+++ b/src/Components/Monpanier.js
@@ -18,7 +18,7 @@ export class Pagepanier extends React.Component {
         <div className="container my-4">
           <div className="row">
             <div className="col-lg-8">
-              <ListePanier Addmore={this.props.Addmore} cart={this.props.cart} />
+              <ListePanier Addmore={this.props.Addmore} cart={this.props.cart} Addproduct={this.props.Addproduct} />
             </div>
             <div className="col-lg-4">
               <div className="summary card p-3">
@@ -107,7 +107,7 @@ export class Pagepanier extends React.Component {
         </div>
     </div>
 </div>
-<Modal src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} />
+<Modal src={this.props.src}  montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} Addproduct={this.props.Addproduct} />
 </div>)
     }
 
@@ -155,7 +155,7 @@ export class Cartepanier extends React.Component{
               <h5 className="mt-2">subtotal: {this.props.montant * this.props.qty}$ </h5>
             </div>
           </div>
-          <Modal src={this.props.src} montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} />
+          <Modal src={this.props.src} montant={this.props.montant} auteur={this.props.auteur} profil={this.props.profil} description={this.props.description} Addproduct={this.props.Addproduct} />
         </div>
       )
     }
@@ -168,6 +168,7 @@ export class Cartepanier extends React.Component{
       return this.props.cart.map((img) => (
         <Cartepanier
           Addmore={this.props.Addmore.bind(this, img)}
+          Addproduct={this.props.Addproduct.bind(this, img)}
           id={img.id}
           titre={img.titre}
           key={img.id}


### PR DESCRIPTION
## Summary
- Forward Addproduct handler through Modal to Description
- Allow modal cart icon to add current product to cart
- Provide Addproduct prop to all Modal usages across cart and listing views

## Testing
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bf9969f50c832babdc74229a464435