### PR TITLE
Add product search filtering with controlled input

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,11 @@ export const Styles = { carteproduit:["carteproduit","carteproduit2","carteprodu
 class App extends React.Component {
   constructor(){
     super();
-   this.state={ produits:[],cart:[]}
+   this.state={ produits:[],cart:[], searchQuery:''}
+  }
+
+  handleSearch = (query) => {
+    this.setState({searchQuery: query});
   }
 
 
@@ -118,6 +122,8 @@ console.log(img)
                   elementscart={this.state.cart}
                   produits={this.state.produits}
                   Addproduct={this.Addproduct}
+                  searchQuery={this.state.searchQuery}
+                  onSearch={this.handleSearch}
                 />
               }
             />

--- a/src/Components/Accueil.js
+++ b/src/Components/Accueil.js
@@ -1,41 +1,31 @@
 import React from "react";
 import { Carteproduit } from "./Carte";
-import { Entete } from  './Entetes';
+import { Entete } from './Entetes';
 import { SectionAccueil } from './SectionAccueil';
 
-
-
- 
-
 export class Mycart extends React.Component{
-
-
-
   render(){
+    const query = (this.props.searchQuery || '').toLowerCase();
+    const filteredProduits = this.props.produits.filter(p => {
+      const titre = (p.titre || '').toLowerCase();
+      const description = (p.description || '').toLowerCase();
+      return titre.includes(query) || description.includes(query);
+    }).slice(0).reverse();
+
     return(
       <div>
-       <SectionAccueil/>
-       
-    
-  
+       <SectionAccueil onSearch={this.props.onSearch} searchQuery={this.props.searchQuery}/>
        <Entete titre={'liste de produits'} />
-     
       <div className="row listeproduits">
-        {this.props.produits.slice(0).reverse().map(img=>{return(
-         
+        {filteredProduits.map(img=>{
+          return(
          <div className='col-xl-3  col-md-4  col-sm-6'>
          <Carteproduit Ajouter2={this.props.Ajouter2} Addproduct={this.props.Addproduct.bind(this, img)}  src={img.src} auteur={img.auteur} montant={img.montant} profil={img.profil} description={img.description} titre={img.titre} key={`clef${img.montant}`+`${img.profil}`+`${img.description}${img.src}`} />
          </div>
         )
         })}
       </div>
-              
     </div>
-
-
-              
-
-      
     )
   }
 }

--- a/src/Components/SectionAccueil.js
+++ b/src/Components/SectionAccueil.js
@@ -6,13 +6,17 @@ export class SectionAccueil extends React.Component{
         return(
             <div className="sectionaccueil">
                    <div className="overlap-group">
-                       <input className="inputtext"></input>
-                      <button className="rectangle-66"><i className="bi bi-search "></i></button>
+                       <input 
+                         className="inputtext"
+                         value={this.props.searchQuery || ''}
+                         onChange={(e) => this.props.onSearch && this.props.onSearch(e.target.value)}
+                       />
+                      <button className="rectangle-66" onClick={() => this.props.onSearch && this.props.onSearch(this.props.searchQuery || '')}><i className="bi bi-search "></i></button>
                    </div>
             </div>
 
         )
-        
+
         
     
     }


### PR DESCRIPTION
## Summary
- Track search query in `App` and pass handler down to product listing
- Filter products by case-insensitive title/description match in `Mycart`
- Convert home search input into a controlled component calling `onSearch`

## Testing
- `CI=true npm test -- --watch=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68bfa206e00c832bb7fb13f0b233bcd4