### PR TITLE
Render saved collection items using existing card component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,7 @@ import { Navigation } from './Components/Navigation';
 import { AjouterProduit } from './Components/Ajouterproduit';
 import {Pagepanier} from './Components/Monpanier'
 import {Mycart} from './Components/Accueil'
-import { InstaCarteproduit } from './Components/Carte';
+import CollectionList from './Components/CollectionList';
 
 
 
@@ -145,17 +145,7 @@ async componentDidMount() {
               }
             />
             <Route path="/Ajouter" element={<AjouterProduit />} />
-            <Route
-              path="/Collection"
-              element={
-                <div>
-                  <h1>Collection</h1>
-                  <div className='row'>
-                    <InstaCarteproduit Addproduct={this.Addproduct} AddtoCollection={this.AddtoCollection} />
-                  </div>
-                </div>
-              }
-            />
+            <Route path="/Collection" element={<CollectionList items={this.state.collection} Addproduct={this.Addproduct} AddtoCollection={this.AddtoCollection} />} />
             <Route path="/Messages" element={<h1>Messages</h1>} />
           </Routes>
         </div>

--- a/src/Components/CollectionList.js
+++ b/src/Components/CollectionList.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Carteproduit } from './Carte';
+
+export const CollectionList = ({ items, Addproduct, AddtoCollection }) => {
+  if (!items || items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className='row'>
+      {items.map((img) => (
+        <div className='col-xl-3 col-md-4 col-sm-6' key={img.id}>
+          <Carteproduit
+            Addproduct={() => Addproduct(img)}
+            AddtoCollection={AddtoCollection}
+            id={img.id}
+            src={img.src}
+            auteur={img.auteur}
+            montant={img.montant}
+            profil={img.profil}
+            description={img.description}
+            titre={img.titre}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default CollectionList;


### PR DESCRIPTION
## Summary
- add `CollectionList` component to display saved items with `Carteproduit`
- update `/Collection` route to render the list when `collection` has entries

## Testing
- `CI=true npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bfa97eeb54832b9fde45e8865f0cb7