### PR TITLE
Add category pages and breadcrumb navigation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import { AjouterProduit } from './Components/Ajouterproduit';
 import {Pagepanier} from './Components/Monpanier'
 import {Mycart} from './Components/Accueil'
 import CollectionList from './Components/CollectionList';
+import CategoryPage from './Components/CategoryPage';
 
 
 
@@ -114,10 +115,11 @@ async componentDidMount() {
 
   render() {
     const cartCount = this.state.cart.reduce((sum, p) => sum + p.qty, 0);
+    const categories = Array.from(new Set(this.state.produits.map(p => p.category))).filter(Boolean);
     return (
       <BrowserRouter>
         <div className="App">
-          <Navigation totalCount={cartCount} />
+          <Navigation totalCount={cartCount} categories={categories} />
           <Routes>
             <Route
               path="/"
@@ -147,6 +149,16 @@ async componentDidMount() {
             <Route path="/Ajouter" element={<AjouterProduit />} />
             <Route path="/Collection" element={<CollectionList items={this.state.collection} Addproduct={this.Addproduct} AddtoCollection={this.AddtoCollection} />} />
             <Route path="/Messages" element={<h1>Messages</h1>} />
+            <Route
+              path="/category/:name"
+              element={
+                <CategoryPage
+                  produits={this.state.produits}
+                  Addproduct={this.Addproduct}
+                  AddtoCollection={this.AddtoCollection}
+                />
+              }
+            />
           </Routes>
         </div>
       </BrowserRouter>

--- a/src/Components/Accueil.js
+++ b/src/Components/Accueil.js
@@ -20,19 +20,20 @@ export class Mycart extends React.Component{
         {filteredProduits.map(img=>{
           return(
          <div className='col-xl-3  col-md-4  col-sm-6'>
-         <Carteproduit
-           Ajouter2={this.props.Ajouter2}
-           Addproduct={this.props.Addproduct.bind(this, img)}
-           AddtoCollection={this.props.AddtoCollection}
-           id={img.id}
-           src={img.src}
-           auteur={img.auteur}
-           montant={img.montant}
-           profil={img.profil}
-           description={img.description}
-           titre={img.titre}
-           key={`clef${img.montant}`+`${img.profil}`+`${img.description}${img.src}`}
-         />
+          <Carteproduit
+            Ajouter2={this.props.Ajouter2}
+            Addproduct={this.props.Addproduct.bind(this, img)}
+            AddtoCollection={this.props.AddtoCollection}
+            id={img.id}
+            src={img.src}
+            auteur={img.auteur}
+            montant={img.montant}
+            profil={img.profil}
+            description={img.description}
+            titre={img.titre}
+            category={img.category}
+            key={`clef${img.montant}`+`${img.profil}`+`${img.description}${img.src}`}
+          />
          </div>
         )
         })}

--- a/src/Components/Breadcrumbs.js
+++ b/src/Components/Breadcrumbs.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Link, useLocation } from 'react-router-dom';
+
+const Breadcrumbs = ({ extra = [] }) => {
+  const location = useLocation();
+  const segments = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .filter((seg) => seg !== 'category');
+
+  const crumbs = [{ name: 'Home', path: '/' }];
+
+  segments.forEach((seg, idx) => {
+    const path = '/' + segments.slice(0, idx + 1).join('/');
+    crumbs.push({ name: decodeURIComponent(seg), path });
+  });
+
+  extra.forEach((name) => {
+    if (name) {
+      crumbs.push({ name });
+    }
+  });
+
+  return (
+    <nav aria-label="breadcrumb">
+      <ol className="breadcrumb">
+        {crumbs.map((c, idx) => (
+          <li key={idx} className="breadcrumb-item">
+            {c.path && idx !== crumbs.length - 1 ? (
+              <Link to={c.path}>{c.name}</Link>
+            ) : (
+              c.name
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+};
+
+export default Breadcrumbs;

--- a/src/Components/Carte.js
+++ b/src/Components/Carte.js
@@ -186,6 +186,7 @@ export class Seller extends React.Component{
         id={this.props.id}
         Addproduct={this.props.Addproduct}
         AddtoCollection={this.props.AddtoCollection}
+        category={this.props.category}
       />
   
       

--- a/src/Components/CategoryPage.js
+++ b/src/Components/CategoryPage.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import CollectionList from './CollectionList';
+import Breadcrumbs from './Breadcrumbs';
+
+const CategoryPage = ({ produits = [], Addproduct, AddtoCollection }) => {
+  const { name } = useParams();
+  const items = produits.filter((p) => p.category === name);
+
+  return (
+    <div className="container mt-4">
+      <Breadcrumbs />
+      <h2 className="mb-4 text-capitalize">{name}</h2>
+      <CollectionList
+        items={items}
+        Addproduct={Addproduct}
+        AddtoCollection={AddtoCollection}
+      />
+    </div>
+  );
+};
+
+export default CategoryPage;

--- a/src/Components/CollectionList.js
+++ b/src/Components/CollectionList.js
@@ -20,6 +20,7 @@ export const CollectionList = ({ items, Addproduct, AddtoCollection }) => {
             profil={img.profil}
             description={img.description}
             titre={img.titre}
+            category={img.category}
           />
         </div>
       ))}

--- a/src/Components/Modal.js
+++ b/src/Components/Modal.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { Options } from "./Commentaires";
+import Breadcrumbs from './Breadcrumbs';
 
 
 
@@ -26,6 +27,7 @@ export class Modal extends React.Component{
         id,
         Addproduct,
         AddtoCollection,
+        category,
       } = this.props;
       return (
         <div
@@ -40,6 +42,7 @@ export class Modal extends React.Component{
             <div className="modalelements">
               <div className="modalrow1">
                 <div className="modalcell">
+                  <Breadcrumbs extra={[category, titre]} />
                   <div>
                     <div className="seller">
                       <div className="options">

--- a/src/Components/Navigation.js
+++ b/src/Components/Navigation.js
@@ -1,10 +1,11 @@
 import React from "react";
-import {images} from '../data/images'
-import { Link,NavLink } from "react-router-dom";
+import { images } from '../data/images';
+import { NavLink } from "react-router-dom";
 import { SectionAccueil2 } from "./SectionAccueil";
 
-export class Navigation extends React.Component{
+export class Navigation extends React.Component {
 render(){
+    const { categories = [] } = this.props;
     return(<div>
         
       
@@ -28,16 +29,14 @@ render(){
                 <li className="nav-item">
                     <NavLink className="nav-link" to="/Messages">Messages <i className="bi bi-chat-left-fill"></i>  </NavLink>
                 </li>
-
-              
-
-
+                {categories.map((cat) => (
+                  <li className="nav-item" key={cat}>
+                    <NavLink className="nav-link" to={`/category/${cat}`}>{cat}</NavLink>
+                  </li>
+                ))}
                 <li className="nav-item">
                     <NavLink className="nav-link" to="/Ajouter">Ajouter un produit  <i className="bi bi-plus-square-fill"></i></NavLink>
                 </li>
-
-                
-
                 <li className="nav-item">
                     <NavLink to="/panier" className="nav-link" >Panier <i className="bi bi-bag-fill"></i><span className='badge badge-warning' id='lblCartCount'> {this.props.totalCount} </span></NavLink>
                 </li>


### PR DESCRIPTION
## Summary
- Introduce reusable Breadcrumbs component that builds a trail from the current route
- Add CategoryPage for filtering products by category and showing breadcrumbs
- Register category routes and expose category links in navigation; product modal now shows breadcrumbs

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68c31ab6c82c832b9e1354c1fecbd615